### PR TITLE
v0.13.0

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -31,6 +31,17 @@
 
 
 # Version Control
+	v0.13.0 - 21 October 2024 (Steve)
+		Added graph button and collapsed graph to each row of the attack tables.
+		Added mini graph to attack tables. 
+			Min and max values are currently set to the full time range. Short attacks will appear as a vertical line. 
+			I might change this later. The current idea is you see at a glance where in the timeline each attack occurred.
+		Customizable graph overhaul.
+			Split into BPS and PPS graphs.
+			Checkboxes simplified to one per attack.
+			Checkboxes will display in multiple columns when there are many attacks.
+			Colors are maintained when checking and unchecking values.
+			Enabled animation.
 	v0.12.2 - 17 October 2024 (Steve)
 		Changed multiple print() statements to update_log() statements for more verbose logging.
 		The script will now output each DefensePro's policy list when prompting user for per DP policy filters.

--- a/common.py
+++ b/common.py
@@ -3,6 +3,7 @@ import datetime
 import sys
 import re
 
+#outputFolder = f'./Output/{datetime.datetime.now().strftime('%Y-%m-%d_%H.%M.%S')}'
 outputFolder = './Output/'
 LogfileName = outputFolder + "P-Attack-Story.log"
 topN = 10 #number of entries to include in the attack table

--- a/html_data.py
+++ b/html_data.py
@@ -72,7 +72,7 @@ def generate_html_report(top_by_bps, top_by_pps, unique_protocols, count_above_t
                 <th>Policy</th>
                 <th>Attack Category</th>
                 <th>Attack Name</th>
-                <th>Threat Group</th>
+                <th>Graph</th>
                 <th>Protocol</th>
                 <th>Action</th>
                 <th>Attack Status</th>
@@ -95,9 +95,9 @@ def generate_html_report(top_by_bps, top_by_pps, unique_protocols, count_above_t
         except (ValueError, TypeError):
             max_attack_rate_bps = 0.0
 
-        # Row class based on threshold
         row_class = ''
-
+        graph_name = f"graph_{(details.get('Attack Name', 'N/A') + "_" + details.get('Attack ID', 'N/A')).replace(" ","_").replace("-","_")}"
+        
         # Main row
         html_content += f"""
             <tr class="{row_class}">
@@ -109,7 +109,8 @@ def generate_html_report(top_by_bps, top_by_pps, unique_protocols, count_above_t
                 <td>{details.get('Policy', 'N/A')}</td>
                 <td>{details.get('Attack Category', 'N/A')}</td>
                 <td>{details.get('Attack Name', 'N/A')}</td>
-                <td>{details.get('Threat Group', 'N/A')}</td>
+                <!-- <td>{details.get('Threat Group', 'N/A')}</td> -->
+                <td><div id="{graph_name}-bpsmini" style="width: 100%; height: 100%;"></div></td>
                 <td>{details.get('Protocol', 'N/A')}</td>
                 <td>{details.get('Action', 'N/A')}</td>
                 <td>{details.get('Attack Status', 'N/A')}</td>
@@ -117,10 +118,19 @@ def generate_html_report(top_by_bps, top_by_pps, unique_protocols, count_above_t
                 <td>{details.get('Max_Attack_Rate_PPS_formatted', 'N/A')}</td>
                 <td>{details.get('Final Footprint', 'N/A')}</td>
                 <td><pre>{metrics_summary}</pre></td>
-                <td><button type="button" class="collapsible" onclick="toggleContent('bps_{details.get('Attack ID', 'N/A')}')">Sample Data</button></td>
+                <td><button type="button" class="collapsible" onclick="toggleContent('bps_{details.get('Attack ID', 'N/A')}')">Sample Data</button>
+                    <button type="button" class="collapsible" onclick="toggleContent('tr_bps_{graph_name}');drawChart_{graph_name}();">Graph</button></td>
+                </td>
             </tr>
         """
-
+        # Collapsible row for graph (initially hidden)
+        html_content += f"""
+            <tr id="tr_bps_{graph_name}" style="display:none;">
+                <td colspan="17">
+                    <div id="{graph_name}-top_n_bps" style="width: 100%; height: 500px;"></div>
+                </td>
+            </tr>
+        """
         # Collapsible row for sample data (initially hidden)
         html_content += f"""
             <tr id="bps_{details.get('Attack ID', 'N/A')}" style="display:none;">
@@ -174,7 +184,7 @@ def generate_html_report(top_by_bps, top_by_pps, unique_protocols, count_above_t
                 <th>Policy</th>
                 <th>Attack Category</th>
                 <th>Attack Name</th>
-                <th>Threat Group</th>
+                <th>Graph</th>
                 <th>Protocol</th>
                 <th>Action</th>
                 <th>Attack Status</th>
@@ -197,8 +207,8 @@ def generate_html_report(top_by_bps, top_by_pps, unique_protocols, count_above_t
         except (ValueError, TypeError):
             max_attack_rate_pps = 0.0
 
-        # Row class based on threshold
         row_class = ''
+        graph_name = f"graph_{(details.get('Attack Name', 'N/A') + "_" + details.get('Attack ID', 'N/A')).replace(" ","_").replace("-","_")}"
 
         # Main row
         html_content += f"""
@@ -211,7 +221,8 @@ def generate_html_report(top_by_bps, top_by_pps, unique_protocols, count_above_t
                 <td>{details.get('Policy', 'N/A')}</td>
                 <td>{details.get('Attack Category', 'N/A')}</td>
                 <td>{details.get('Attack Name', 'N/A')}</td>
-                <td>{details.get('Threat Group', 'N/A')}</td>
+                <!-- <td>{details.get('Threat Group', 'N/A')}</td> -->
+                <td><div id="{graph_name}-ppsmini"></div></td>
                 <td>{details.get('Protocol', 'N/A')}</td>
                 <td>{details.get('Action', 'N/A')}</td>
                 <td>{details.get('Attack Status', 'N/A')}</td>
@@ -219,10 +230,21 @@ def generate_html_report(top_by_bps, top_by_pps, unique_protocols, count_above_t
                 <td>{details.get('Max_Attack_Rate_PPS_formatted', 'N/A')}</td>
                 <td>{details.get('Final Footprint', 'N/A')}</td>
                 <td><pre>{metrics_summary}</pre></td>
-                <td><button type="button" class="collapsible" onclick="toggleContent('pps_{details.get('Attack ID', 'N/A')}')">Sample Data</button></td>
+                <td>\
+                    <button type="button" class="collapsible" onclick="toggleContent('pps_{details.get('Attack ID', 'N/A')}')">Sample Data</button>
+                    <button type="button" class="collapsible" onclick="toggleContent('tr_pps_{graph_name}');drawChart_{graph_name}();">Graph</button>
+                </td>
             </tr>
         """
-
+        # Collapsible row for graph
+        html_content += f"""
+            <tr id="tr_pps_{graph_name}" style="display:none;">
+                <td></td>
+                <td colspan="17">
+                    <div id="{graph_name}-top_n_pps" style="width: 100%; height: 500px;"></div>
+                </td>
+            </tr>
+        """
         # Collapsible row for sample data (initially hidden)
         html_content += f"""
             <tr id="pps_{details.get('Attack ID', 'N/A')}" style="display:none;">
@@ -270,7 +292,7 @@ def generate_html_report(top_by_bps, top_by_pps, unique_protocols, count_above_t
 
     # Generate HTML content for combined unique IPs as a table
     html_content += """
-    <h2> Unique Sample Source IPs</h2>
+    Sample data source IP functions: 
     <button onclick="copyIPs()">Copy IPs</button>
     <button onclick="toggleTable()">Show Source IP Table</button>
     <div id="ipTableContainer" style="display: none;">

--- a/html_header.py
+++ b/html_header.py
@@ -3,7 +3,9 @@ def getHeader(stats):
     header=f"""\
 <html>
   <head>
-    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js">
+    google.charts.load('current', {{'packages':['corechart', 'annotationchart']}});
+    </script>
     <title>DP Attack Story</title>
     {getCSS()}
   </head>
@@ -20,6 +22,7 @@ def getHeader(stats):
 
 def getCSS():
     """Returns CSS to be included in the header."""
+
     return """<style>
         table {
             width: 100%;
@@ -33,6 +36,7 @@ def getCSS():
         }
         th {
             background-color: #f2f2f2;
+            text-align: center;
         }
         h2 {
             text-align: center;
@@ -50,7 +54,8 @@ def getCSS():
             padding: 5px;
             width: 100%;
             border: none;
-            text-align: left;
+            text-align: center;
+            margin: 4px 2px;
             outline: none;
             font-size: 15px;
             text-align: center;

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import os
 import traceback
 import json
 import datetime
-
+import tarfile
 
 #internal modules
 import clsVision
@@ -31,6 +31,7 @@ if __name__ == '__main__':
                         os.unlink(file_path)
                 except Exception as e:
                     update_log(f"Failed to delete {file_path}. Reason: {e}")
+            pass
         else:
             # Create the output folder if it doesn't exist
             os.makedirs(outputFolder)
@@ -177,7 +178,7 @@ Policies: {"All" if len(policies) == 0 else policies}"""
         try:
             with open(outputFolder + 'AttackGraphsData.json') as data_file:
                 attackGraphData = json.load(data_file)
-            finalHTML += html_graphs.createCombinedChart("All Attacks", attackGraphData) 
+            finalHTML += html_graphs.createCombinedChart("Custom", attackGraphData) 
         except:
             update_log("Unexpected createCombinedChart() error: ")
             traceback.print_exc()
@@ -185,7 +186,7 @@ Policies: {"All" if len(policies) == 0 else policies}"""
         #Add an individual graph for each attack
         for attackID, data in attackGraphData.items():
             try:
-                finalHTML += html_graphs.createSingleChart(attackID, data)
+                finalHTML += html_graphs.createChart(attackID, data, epoch_from_time, epoch_to_time)
             except:
                 update_log(f"Error graphing attackID '{attackID}':")
                 traceback.print_exc()


### PR DESCRIPTION
	v0.13.0 - 21 October 2024 (Steve)
		Added graph button and collapsed graph to each row of the attack tables.
		Added mini graph to attack tables. 
			Min and max values are currently set to the full time range. Short attacks will appear as a vertical line. 
			I might change this later. The current idea is you see at a glance where in the timeline each attack occurred.
		Customizable graph overhaul.
			Split into BPS and PPS graphs.
			Checkboxes simplified to one per attack.
			Checkboxes will display in multiple columns when there are many attacks.
			Colors are maintained when checking and unchecking values.
			Enabled animation.