### PR TITLE
v0.16.5 - 3 January 2025 (Steve + Prateek)

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -73,6 +73,8 @@
 
 
 # Version Control
+	v0.16.5 - 3 January 2025 (Steve + Prateek)
+		hardcoded excluding packet anomalies and changed the use configurable exclude filter in ini file to be attack name based. See: [General] - ExcludeFilters. Default is "DOSS-DNS-Ref-L4-Above-3000"
 	v0.16.4 - 3 January 2025 (Steve + Prateek)
 		Added custom exclude filter option to ini file. See: [General] - ExcludeFilters. Default is "Anomalies,DOSShield"
 	v0.16.3 - 31 December 2024 (Steve)

--- a/clsVision.py
+++ b/clsVision.py
@@ -299,18 +299,25 @@ class clsVision:
                 "inverseFilter": True,
                 "field": "enrichmentContainer.eaaf.eaaf",
                 "value": "true"
+            },
+            {
+                "type": "termFilter",
+                "inverseFilter": True,
+                "field": "ruleName",
+                "value": "Packet Anomalies"
             }
         ]
-        excludes = config.get("General","ExcludeFilters","Anomalies")
-        for exclude in excludes.split(","):
-            criteria.append(
-                    {
-                        "type": "termFilter",
-                        "inverseFilter": True,
-                        "field": "category",
-                        "value": exclude.strip()
-                    }
-                )
+        excludes = config.get("General","ExcludeFilters", "")
+        if len(excludes) > 0:
+            for exclude in excludes.split(","):
+                criteria.append(
+                        {
+                            "type": "termFilter",
+                            "inverseFilter": True,
+                            "field": "name",
+                            "value": exclude.strip()
+                        }
+                    )
         if filter_json:
             criteria.append(filter_json)
 

--- a/common.py
+++ b/common.py
@@ -79,7 +79,7 @@ class clsConfig():
         if not self.config.has_option('General', 'minimum_minutes_between_waves'):
             self.set('General','minimum_minutes_between_waves','5')
         if not self.config.has_option('General', 'ExcludeFilters'):
-            self.set('General','ExcludeFilters','Anomalies, DOSShield')
+            self.set('General','ExcludeFilters','DOSS-DNS-Ref-L4-Above-3000')
             
         #if not self.config.has_option('General', 'Compress_Output'):
         #    self.set("General","Compress_Output","TRUE")

--- a/config.ini.example
+++ b/config.ini.example
@@ -6,7 +6,7 @@ rootpassword = radware
 
 [General]
 Top_N = 10
-ExcludeFilters = Anomalies,DOSShield
+ExcludeFilters = DOSS-DNS-Ref-L4-Above-3000
 
 [PreviousRun]
 epoch_from_time = 1727907868000


### PR DESCRIPTION
hardcoded excluding packet anomalies and changed the use configurable exclude filter in ini file to be attack name based. See: [General] - ExcludeFilters. Default is "DOSS-DNS-Ref-L4-Above-3000"